### PR TITLE
changed SPM dependency declaration to work w/ Swift 5.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,14 +31,14 @@ let Application = Package(
     .executable(name: "Application", targets: ["Application"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/compnerd/swift-win32.git",
+    .package(name: "SwiftWin32", url: "https://github.com/compnerd/swift-win32.git",
              .branch("main")),
   ],
   targets: [
     .executableTarget(
       name: "Application",
       dependencies: [
-        .product(name: "SwiftWin32", package: "swift-win32"),
+        "SwiftWin32",
       ],
       exclude: [
         "Application.exe.manifest",


### PR DESCRIPTION
While the current way of declaring SwiftWin32 as dependency, with `.product(name: "SwiftWin32", package: "swift-win32")`, works for Swift 5.5-dev. This PR changes the project and target dependency declarations so they work with the current stable version of Swift 5.4, It compiled on both .0 and .1 releases of 5.4, and on 5.5-dev.
